### PR TITLE
Improve Prose component styles

### DIFF
--- a/components/content/ProseA.vue
+++ b/components/content/ProseA.vue
@@ -1,5 +1,23 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ href?: string }>()
+const isExternal = computed(() => props.href?.startsWith('http'))
+</script>
+
 <template>
-  <a class="text-primary-600 hover:text-primary-500 underline decoration-primary-600/30">
+  <a
+    :href="props.href"
+    :target="isExternal ? '_blank' : undefined"
+    :rel="isExternal ? 'noopener noreferrer' : undefined"
+    class="text-primary-600 underline decoration-primary-600/30 hover:text-primary-500"
+    :class="[
+      'rounded focus-visible:outline-none focus-visible:ring-2',
+      'focus-visible:ring-primary-500 focus-visible:ring-offset-2',
+      'focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-900',
+      'transition-colors'
+    ]"
+  >
     <slot />
   </a>
 </template>

--- a/components/content/ProseH1.vue
+++ b/components/content/ProseH1.vue
@@ -1,5 +1,19 @@
+<script setup lang="ts">
+const props = defineProps<{ id?: string }>()
+</script>
+
 <template>
-  <h1 class="text-4xl font-extrabold tracking-tight text-zinc-900 dark:text-zinc-100 mb-6">
+  <h1
+    :id="props.id"
+    class="relative group text-4xl font-extrabold tracking-tight text-zinc-900 dark:text-zinc-100 mb-6 border-b border-zinc-200 dark:border-zinc-700 pb-2 scroll-mt-28">
+    <a
+      v-if="props.id"
+      :href="`#${props.id}`"
+      class="absolute -left-6 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity"
+      aria-label="Anchor"
+    >
+      <span aria-hidden="true">#</span>
+    </a>
     <slot />
   </h1>
 </template>

--- a/components/content/ProseH2.vue
+++ b/components/content/ProseH2.vue
@@ -1,5 +1,19 @@
+<script setup lang="ts">
+const props = defineProps<{ id?: string }>()
+</script>
+
 <template>
-  <h2 class="text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100 mt-10 mb-4">
+  <h2
+    :id="props.id"
+    class="relative group text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100 mt-12 mb-4 border-b border-zinc-200 dark:border-zinc-700 pb-1 scroll-mt-24">
+    <a
+      v-if="props.id"
+      :href="`#${props.id}`"
+      class="absolute -left-6 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity"
+      aria-label="Anchor"
+    >
+      <span aria-hidden="true">#</span>
+    </a>
     <slot />
   </h2>
 </template>

--- a/components/content/ProsePre.vue
+++ b/components/content/ProsePre.vue
@@ -17,18 +17,19 @@ async function copy () {
 <template>
   <div class="relative my-6 group/not-prose">
     <pre
-      class="overflow-x-auto rounded-lg p-4 text-sm leading-relaxed
-             bg-zinc-900/90 text-zinc-100">
+      class="overflow-x-auto rounded-xl p-4 text-sm leading-relaxed font-mono border border-zinc-800 bg-zinc-900/75 text-zinc-100">
       <code ref="codeRef" class="block"><slot /></code>
     </pre>
 
     <button
       @click="copy"
-      class="absolute top-2 right-2 flex items-center gap-1 rounded-md
-             bg-zinc-700/70 hover:bg-zinc-700 text-xs text-white px-2 py-1
-             opacity-0 group-hover/not-prose:opacity-100 transition-opacity">
-      <span v-if="copied">Copied ✓</span>
-      <span v-else>Copy</span>
+      class="absolute top-2 right-2 flex items-center gap-1 rounded-md bg-primary-600/80 hover:bg-primary-600 text-xs text-white px-2 py-1 opacity-0 group-hover/not-prose:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
+      :aria-label="copied ? 'Copied' : 'Copy to clipboard'"
+    >
+      <span aria-live="polite">
+        <span v-if="copied">Copied ✓</span>
+        <span v-else>Copy</span>
+      </span>
     </button>
   </div>
 </template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -44,9 +44,14 @@
 //     primary: '#2563eb'
 //   }
 // })
+import { existsSync } from 'node:fs'
+
 export default defineNuxtConfig({
   modules: ['@nuxt/content', '@nuxtjs/tailwindcss', '@nuxtjs/color-mode'],
-  css: ['katex/dist/katex.min.css'],
+  css: [
+    '~/assets/css/tailwind.css',
+    ...(existsSync('node_modules/katex/dist/katex.min.css') ? ['katex/dist/katex.min.css'] : [])
+  ],
   content: {
      documentDriven: true,
      highlight: {


### PR DESCRIPTION
## Summary
- tweak Nuxt config to avoid missing KaTeX CSS
- enhance external link behavior in `ProseA`
- add hoverable anchors to headings
- improve copy button accessibility in `ProsePre`

## Testing
- `npm run build` *(fails: nuxt not found)*